### PR TITLE
Change license to MIT/Apache-2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ethereum-bn128"
 version = "0.1.1"
 authors = ["Parity Technologies <admin@parity.io>","Alex Beregszaszi <alex@rtfs.hu>"]
-license = "GPL-3.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/ewasm/ethereum-bn128.rs"
 description = "Ethereum BN128 helpers for Rust"
 publish = false


### PR DESCRIPTION
Since all upstream projects this depends on are licensed MIT/Apache-2.0, this could be possible:
- https://github.com/paritytech/bn
- https://crates.io/crates/ethereum-types
- https://crates.io/crates/rustc-hex

This of course needs acceptance from all contributors, which is @jwasinger and @aarlt.